### PR TITLE
not use Contextual::Return

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,7 +1,6 @@
 requires 'perl', '5.010001';
 
 requires 'Exporter';
-requires 'Contextual::Return', '0.004014';
 requires 'Carp';
 
 on 'configure' => sub {

--- a/lib/Contextual/Diag/Value.pm
+++ b/lib/Contextual/Diag/Value.pm
@@ -74,8 +74,12 @@ sub AUTOLOAD {
     my $self = shift;
     our $AUTOLOAD;
 
+    unless (ref $self) {
+        die "cannot AUTOLOAD in class call"
+    }
+
     my $obj = do {
-        my $id    = Scalar::Util::refaddr $self;
+        my $id = Scalar::Util::refaddr $self;
         my $data  = $DATA{$id};
         my $code  = $data->{overload}->{OBJREF};
         my $value = $data->{value};

--- a/lib/Contextual/Diag/Value.pm
+++ b/lib/Contextual/Diag/Value.pm
@@ -1,0 +1,92 @@
+package Contextual::Diag::Value;
+use 5.010;
+use strict;
+use warnings;
+
+our $VERSION = "0.02";
+
+use Scalar::Util ();
+
+my %DATA;
+
+sub new {
+    my ($class, $value, %overload) = @_;
+
+    # Use inside-out to prevent infinite recursion
+    my $self = bless \my $scalar => $class;
+    my $id = Scalar::Util::refaddr $self;
+    $DATA{$id} = {
+        value => $value,
+        overload => \%overload,
+    };
+    return $self;
+}
+
+sub _gen_overload {
+    my $context = shift;
+
+    return sub {
+        my $self = shift;
+
+        my $id    = Scalar::Util::refaddr $self;
+        my $data  = $DATA{$id};
+        my $code  = $data->{overload}->{$context};
+        my $value = $data->{value};
+        return $code->($value);
+    }
+}
+
+use overload 
+    q{""}    => _gen_overload('STR'),
+    '0+'     => _gen_overload('NUM'),
+    'bool'   => _gen_overload('BOOL'),
+    '${}'    => _gen_overload('SCALARREF'),
+    '@{}'    => _gen_overload('ARRAYREF'),
+    '&{}'    => _gen_overload('CODEREF'),
+    '%{}'    => _gen_overload('HASHREF'),
+    '*{}'    => _gen_overload('GLOBREF'),
+    fallback => 1;
+
+sub can {
+    my ($invocant) = @_;
+    if (ref $invocant) {
+        our $AUTOLOAD = 'can';
+        goto &AUTOLOAD;
+    }
+    return $invocant->SUPER::can(@_[1..$#_]);
+}
+
+sub isa {
+    my ($invocant) = @_;
+    if (ref $invocant) {
+        our $AUTOLOAD = 'isa';
+        goto &AUTOLOAD;
+    }
+    return $invocant->SUPER::isa(@_[1..$#_]);
+}
+
+sub AUTOLOAD {
+    my $self = shift;
+    our $AUTOLOAD;
+
+    my $obj = do {
+        my $id    = Scalar::Util::refaddr $self;
+        my $data  = $DATA{$id};
+        my $code  = $data->{overload}->{OBJREF};
+        my $value = $data->{value};
+        my $obj   = $code->($value);
+        $obj;
+    };
+
+    my ($method) = $AUTOLOAD =~ m{ .* :: (.*) }xms ? $1 : $AUTOLOAD;
+    return $obj->$method(@_);
+}
+
+sub DESTROY {
+    my $self = shift;
+    my $id    = Scalar::Util::refaddr $self;
+    delete $DATA{$id};
+    return;
+}
+
+1;

--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -144,4 +144,12 @@ subtest 'evaluated as OBJREF' => sub {
     like( warnings { is contextual_diag($obj)->hello('world'), 'hello world' }, $expected );
 };
 
+subtest 'override can/isa' => sub {
+    ok(Contextual::Diag::Value->can('new'));
+    ok(!Contextual::Diag::Value->can('hoge'));
+    ok(Contextual::Diag::Value->isa('Contextual::Diag::Value'));
+    ok(Contextual::Diag::Value->isa('UNIVERSAL'));
+    ok(!Contextual::Diag::Value->isa('Hoge'));
+};
+
 done_testing;

--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -150,6 +150,10 @@ subtest 'override can/isa' => sub {
     ok(Contextual::Diag::Value->isa('Contextual::Diag::Value'));
     ok(Contextual::Diag::Value->isa('UNIVERSAL'));
     ok(!Contextual::Diag::Value->isa('Hoge'));
+
+    like dies {
+        Contextual::Diag::Value->hoge;
+    }, qr/cannot AUTOLOAD in class call/;
 };
 
 done_testing;

--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -120,9 +120,28 @@ subtest 'evaluated as OBJREF' => sub {
         qr/^wanted SCALAR context/,
         qr/^scalar ref is evaluated as OBJREF/,
     ];
-    my $obj = bless {}, 'Some';
-    like( warnings { contextual_diag()->can('somemethod') }, $expected );
-    like( warnings { contextual_diag($obj)->can('somemethod') }, $expected );
+
+    {
+        package Foo;
+        sub new {
+            my $class = shift;
+            return bless {}, $class
+        };
+
+        sub hello {
+            my ($self, $message) = @_;
+            return "hello $message"
+        }
+    }
+
+    my $obj = Foo->new;
+    like( warnings { ok !contextual_diag()->can('somemethod') }, $expected );
+    like( warnings { ok !contextual_diag()->isa('Some') }, $expected );
+    like( warnings { ok !contextual_diag($obj)->can('somemethod') }, $expected );
+    like( warnings { ok contextual_diag($obj)->can('new') }, $expected );
+    like( warnings { ok !contextual_diag($obj)->isa('Hoge') }, $expected );
+    like( warnings { ok contextual_diag($obj)->isa('Foo') }, $expected );
+    like( warnings { is contextual_diag($obj)->hello('world'), 'hello world' }, $expected );
 };
 
 done_testing;


### PR DESCRIPTION
Contextual::Return does more than what Contextual::Diag wants to do, so cut down on the functionality.

Key points of Contextual::Diag::Value
- Use overload to hook each operation
- Only OBJREF can't be hooked by overload, so AUTOLOAD is used.
